### PR TITLE
Update devcontainer configuration and dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,12 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers-contrib/features/ansible:2": {},
-    "ghcr.io/devcontainers-contrib/features/flake8:2": {},
-    "ghcr.io/devcontainers-contrib/features/yamllint:2": {}
+    // "ghcr.io/devcontainers-contrib/features/flake8:2": {},
+    "ghcr.io/devcontainers-contrib/features/yamllint:2": {},
+    "ghcr.io/hspaans/devcontainer-features/ansible-lint:1": {},
+    "ghcr.io/hspaans/devcontainer-features/pytest:1": {
+      "plugins": "pytest-testinfra"
+    }
   },
   "customizations": {
     "vscode": {
@@ -23,6 +27,5 @@
       "ansible.python.interpreterPath": "/usr/local/bin/python",
       "python.formatting.provider": "none"
     }
-  },
-  "postCreateCommand": "pip install -r requirements.txt"
+  }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,3 @@ updates:
           - "*"
     assignees:
       - "hspaans"
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: monthly
-    groups:
-      Python:
-        patterns:
-          - "*"
-    assignees:
-      - "hspaans"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-ansible-lint==6.22.2
-pytest==8.0.0
-pytest-testinfra==10.0.0


### PR DESCRIPTION
This pull request updates the devcontainer configuration and dependencies. It includes the following changes:

- Added the `ghcr.io/hspaans/devcontainer-features/ansible-lint:1` feature

- Added the `ghcr.io/hspaans/devcontainer-features/pytest:1` feature with the `pytest-testinfra` plugin

- Removed the `ghcr.io/devcontainers-contrib/features/flake8:2` feature

- Updated the `ghcr.io/devcontainers-contrib/features/yamllint:2` feature

- Removed the unused `requirements.txt` file

Please review and merge.